### PR TITLE
Fix file missing error on embroider when using custom rootURL

### DIFF
--- a/packages/ember-svg-jar/public/index.html
+++ b/packages/ember-svg-jar/public/index.html
@@ -104,6 +104,7 @@
     </style>
 
     <link
+      data-embroider-ignore
       href="{{ROOT_URL}}ember-svg-jar/static/css/main.f3aef49e.chunk.css"
       rel="stylesheet"
     />
@@ -201,7 +202,7 @@
         a();
       })([]);
     </script>
-    <script src="{{ROOT_URL}}ember-svg-jar/static/js/2.ced0fc45.chunk.js"></script>
-    <script src="{{ROOT_URL}}ember-svg-jar/static/js/main.0e7a56b1.chunk.js"></script>
+    <script data-embroider-ignore src="{{ROOT_URL}}ember-svg-jar/static/js/2.ced0fc45.chunk.js"></script>
+    <script data-embroider-ignore src="{{ROOT_URL}}ember-svg-jar/static/js/main.0e7a56b1.chunk.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Using ember-svg-jar with custom rootURL in Embroider app, throws the below mentioned error and the chunk js and css are missing from final build.
```
Building into /private/var/folders/qt/rbrkt7wx48vggvxs2tcnzy70zb1g2b/T/embroider/270ee5
Environment: development
⠏ building... [@embroider/webpack]warning: in ./ember-svg-jar/index.html <script src="customrooturl/ember-svg-jar/static/js/2.ced0fc45.chunk.js"> does not exist on disk. If this is intentional, use a data-embroider-ignore attribute.
warning: in ./ember-svg-jar/index.html <script src="customrooturl/ember-svg-jar/static/js/main.0e7a56b1.chunk.js"> does not exist on disk. If this is intentional, use a data-embroider-ignore attribute.
warning: in ./ember-svg-jar/index.html  <link rel="stylesheet" href="customrooturl/ember-svg-jar/static/css/main.f3aef49e.chunk.css"> does not exist on disk. If this is intentional, use a data-embroider-ignore attribute.
assets by status 2.32 MiB [big]
```