### PR TITLE
Speed up requiring `index.js` file

### DIFF
--- a/packages/ember-svg-jar/lib/utils.js
+++ b/packages/ember-svg-jar/lib/utils.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const fs = require('fs');
-const cheerio = require('cheerio').default;
 const path = require('path').posix;
 const osPathSep = require('path').sep;
 const _ = require('lodash');
@@ -30,6 +29,8 @@ function makeIDForPath(relativePath, { idGen, stripPath, prefix }) {
 }
 
 function svgDataFor(svgContent) {
+  const cheerio = require('cheerio').default;
+
   let $svg = cheerio.load(svgContent, { xmlMode: true })('svg');
 
   return {


### PR DESCRIPTION
Ember CLI requires every addon's `index.js` file when running any command.
I noticed that requiring `ember-svg-jar`'s `index.js` file takes a bit of time.
This PR should speed things up a bit by only requiring some packages when they are actually used.

Before: 170-180ms
After: 25-30ms

Tested on an Apple M1 Pro MacBook using:

```js
console.time('require');
require('./index.js');
console.timeEnd('require');
```