### PR TITLE
Allow null as arguments type

### DIFF
--- a/packages/ember-svg-jar/addon/types.ts
+++ b/packages/ember-svg-jar/addon/types.ts
@@ -5,12 +5,12 @@ type SvgJarAssetId = string;
 type SvgJarPositional = [SvgJarAssetId];
 
 interface SvgJarAttrs {
-  width?: string;
-  height?: string;
-  class?: string;
-  role?: string;
-  title?: string;
-  desc?: string;
+  width?: string | null;
+  height?: string | null;
+  class?: string | null;
+  role?: string | null;
+  title?: string | null;
+  desc?: string | null;
 }
 
 type SvgJarReturn = SVGElement;

--- a/packages/ember-svg-jar/addon/types.ts
+++ b/packages/ember-svg-jar/addon/types.ts
@@ -5,6 +5,7 @@ type SvgJarAssetId = string;
 type SvgJarPositional = [SvgJarAssetId];
 
 interface SvgJarAttrs {
+  fill?: string | null;
   width?: string | null;
   height?: string | null;
   class?: string | null;


### PR DESCRIPTION
When using `{{svg-jar}}` helper, optional named arguments need to be `null` (so they can be filtered out in via `isNone` in https://github.com/ghedamat/ember-svg-jar/blob/v2.4.6/packages/ember-svg-jar/addon/utils/make-svg.js#L107).

If argument value is `undefined`, it gets added to DOM, which may cause issues with arguments like `width` and `height`.

This PR fixes types to add `null` as allowed arg type.